### PR TITLE
Added two new Go rules

### DIFF
--- a/go/racy-append-to-slice.yml
+++ b/go/racy-append-to-slice.yml
@@ -1,0 +1,35 @@
+rules:
+- id: racy-append-to-slice
+  languages:
+    - go
+  patterns:
+    - pattern: |
+          $SLICE = append($SLICE, $ITEM)
+    - pattern-either:
+      - pattern-inside: |
+          var $SLICE []$TYPE
+          ...
+          for ... {
+            ...
+            go func(...) {
+              ...
+              $SLICE = append($SLICE, $ITEM)
+              ...
+            }(...)
+            ...
+          }
+      - pattern-inside: |
+          $SLICE := make([]$TYPE, ...)
+          ...
+          for ... {
+            ...
+            go func(...) {
+              ...
+              $SLICE = append($SLICE, $ITEM)
+              ...
+            }(...)
+            ...
+          }
+  message: |
+    Appending $SLICE from multiple goroutines is not concurrency safe.
+  severity: ERROR

--- a/go/racy-write-to-map.yml
+++ b/go/racy-write-to-map.yml
@@ -1,5 +1,5 @@
 rules:
-- id: racy-add-to-map
+- id: racy-write-to-map
   languages:
     - go
   patterns:

--- a/go/racy-write-to-map.yml
+++ b/go/racy-write-to-map.yml
@@ -1,0 +1,35 @@
+rules:
+- id: racy-add-to-map
+  languages:
+    - go
+  patterns:
+    - pattern: |
+          $MAP[$KEY] = $VALUE
+    - pattern-either:
+      - pattern-inside: |
+          $MAP = make(map[$KTYPE]$VTYPE)
+          ...
+          for ... {
+            ...
+            go func(...) {
+              ...
+              $MAP[$KEY] = $VALUE
+              ...
+            }(...)
+            ...
+          }
+      - pattern-inside: |
+          $MAP := make(map[$KTYPE]$VTYPE)
+          ...
+          for ... {
+            ...
+            go func(...) {
+              ...
+              $MAP[$KEY] = $VALUE
+              ...
+            }(...)
+            ...
+          }
+  message: |
+    Writing $MAP from multiple goroutines is not concurrency safe.
+  severity: ERROR


### PR DESCRIPTION
Added [`racy-append-to-slice`](https://github.com/trailofbits/semgrep-rules/blob/feature/racy-write/go/racy-append-to-slice.yml) which detects concurrent appends to the same
slice, and [`racy-write-to-map`](https://github.com/trailofbits/semgrep-rules/blob/feature/racy-write/go/racy-write-to-map.yml) which detects concurrent writes to the
same map.