### PR TITLE
Fixed rule to cover when open() use several arguments

### DIFF
--- a/python/tarfile-extractall-traversal.py
+++ b/python/tarfile-extractall-traversal.py
@@ -32,6 +32,9 @@ def extract_3(args):
     tf = tarfile.open(path)
     tf.extractall(save_path)
 
+def extract_4(args, tarobj):
+    tf = tarfile.open(mode='r', fileobj=None)
+    tf.extractall(save_path)
 
 def run():
     parser = get_parser()

--- a/python/tarfile-extractall-traversal.py
+++ b/python/tarfile-extractall-traversal.py
@@ -33,6 +33,7 @@ def extract_3(args):
     tf.extractall(save_path)
 
 def extract_4(args, tarobj):
+    # ruleid: tarfile-extractall-traversal
     tf = tarfile.open(mode='r', fileobj=None)
     tf.extractall(save_path)
 

--- a/python/tarfile-extractall-traversal.yml
+++ b/python/tarfile-extractall-traversal.yml
@@ -3,13 +3,13 @@ rules:
   patterns:
     - pattern-either: 
       - pattern: |
-          with tarfile.open($PATH) as $TAR:
+          with tarfile.open(...) as $TAR:
               ...
               $TAR.extractall($DESTPATH)
       - pattern: |
-          tarfile.open($PATH).extractall($DESTTPATH)
+          tarfile.open(...).extractall($DESTTPATH)
       - pattern: |
-          $TAR = tarfile.open($PATH)
+          $TAR = tarfile.open(...)
           ...
           $TAR.extractall($DESTTPATH)
   message: |


### PR DESCRIPTION
I found that the rule was not detecting properly when open() was using more than one argument.
I modified the detection rule so the number of argument doesn't matter. I also added a test to verify it was working properly.