### PR TITLE
added a fix for FPs found by anonymous-race-condition

### DIFF
--- a/go/anonymous-race-condition.go
+++ b/go/anonymous-race-condition.go
@@ -173,3 +173,36 @@ func AnonRaceCond_4_FP() {
 
 	wg.Wait()
 }
+
+
+func AnonRaceCond_5() {
+	var wg sync.WaitGroup
+	// ok: anonymous-race-condition
+	for idx, val := range values {
+		wg.Add(1)
+		idx, val := idx, val
+		go func() {
+			val.s.Method("test")
+			fmt.Println("Completed index", idx)
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
+}
+
+func AnonRaceCond_6() {
+	var wg sync.WaitGroup
+	// ok: anonymous-race-condition
+	for idx, val := range values {
+		wg.Add(1)
+		idx, val := idx, val
+		go func() {
+			fmt.Println(val.s)
+			fmt.Println("Completed index", idx)
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
+}

--- a/go/anonymous-race-condition.yaml
+++ b/go/anonymous-race-condition.yaml
@@ -112,3 +112,23 @@ rules:
           }(...)
           ...
         }
+    - pattern-not: |
+        for $Y, $X := range ... {
+          ...
+          $Y, $X := $Y, $X
+          ...
+          go func(...){
+            ...
+            <... $X.$VAR ...>
+          }(...)
+        }
+    - pattern-not: |
+        for $Y, $X := range ... {
+          ...
+          $Y, $X := $Y, $X
+          ...
+          go func(...){
+            ...
+            <... $Y.$VAR ...>
+          }(...)
+        }


### PR DESCRIPTION
The anonymous-race-condition rule was returning FPs for cases such as these where the two loop variables are shadowed and later used in an anon func:

```go
func AnonRaceCond_5() {
	var wg sync.WaitGroup
	for idx, val := range values {
		wg.Add(1)
		idx, val := idx, val
		go func() {
			val.s.Method("test")
			fmt.Println("Completed index", idx)
			wg.Done()
		}()
	}

	wg.Wait()
}

func AnonRaceCond_6() {
	var wg sync.WaitGroup
	for idx, val := range values {
		wg.Add(1)
		idx, val := idx, val
		go func() {
			fmt.Println(val.s)
			fmt.Println("Completed index", idx)
			wg.Done()
		}()
	}

	wg.Wait()
}
```

This add two `pattern-not` that fix that.