### PR TITLE
CODEOWNERS: update

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 * @GrosQuildu
-/go/ @hex0punk @GrosQuildu @Vasco-jofra
+/go/ @GrosQuildu @Vasco-jofra
 /python/ @suhacker1 @GrosQuildu @Vasco-jofra


### PR DESCRIPTION
Removes `@hex0punk` (GitHub complains that he's no longer an org member, and therefore the file is invalid with him in it).