### PR TITLE
Remove dev.semgrep.dev from update-registry job

### DIFF
--- a/.github/workflows/update-semgrep-registry.yml
+++ b/.github/workflows/update-semgrep-registry.yml
@@ -9,6 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: update staging.semgrep.dev
-        run: curl --fail -X POST -L https://staging.semgrep.dev/api/admin/update-registry
+        run: curl --fail -X POST -L https://staging.semgrep.dev/api/admin/update-registry?rule_type=sast
       - name: update semgrep.dev
-        run: curl --fail -X POST -L https://semgrep.dev/api/admin/update-registry
+        run: curl --fail -X POST -L https://semgrep.dev/api/admin/update-registry?rule_type=sast

--- a/.github/workflows/update-semgrep-registry.yml
+++ b/.github/workflows/update-semgrep-registry.yml
@@ -8,8 +8,6 @@ jobs:
     name: Update semgrep.dev
     runs-on: ubuntu-latest
     steps:
-      - name: update dev.semgrep.dev
-        run: curl --fail -X POST -L https://dev.semgrep.dev/api/admin/update-registry
       - name: update staging.semgrep.dev
         run: curl --fail -X POST -L https://staging.semgrep.dev/api/admin/update-registry
       - name: update semgrep.dev


### PR DESCRIPTION
It looks like this job started failing within the past 3 months: https://github.com/trailofbits/semgrep-rules/actions/workflows/update-semgrep-registry.yml.

I'm seeing the same behavior locally:

```
$ curl --fail -X POST -L https://dev.semgrep.dev/api/admin/update-registry
curl: (22) The requested URL returned error: 404
$ curl --fail -X POST -L https://staging.semgrep.dev/api/admin/update-registry
{"status":"Started processing"}
$ curl --fail -X POST -L https://semgrep.dev/api/admin/update-registry
{"status":"Started processing"}
```

cc @LewisArdern does this look correct to you?