### PR TITLE
Fix unbounded ellipsis match in tar-insecure-flags rule

### DIFF
--- a/generic/tar-insecure-flags.sh
+++ b/generic/tar-insecure-flags.sh
@@ -11,3 +11,9 @@ tar -xvf --Psomeotherflag archive.tar
 
 # ok: tar-insecure-flags
 tar -xvf archive.tar
+
+# Unbounded ellipsis span in pattern wraps to next command in some scenarios
+wget https://git.kernel.org/torvalds/t/linux-6.8-rc1.tar.gz -O - | tar -xz -C / && mv linux-6.8-rc1 linux
+
+# This shouldn't match, but the ellipsis wrap picks up the p flag in this command and associates it with the previous command
+wget https://github.com/trailofbits/semgrep-rules -P /ToB/

--- a/generic/tar-insecure-flags.sh
+++ b/generic/tar-insecure-flags.sh
@@ -13,6 +13,7 @@ tar -xvf --Psomeotherflag archive.tar
 tar -xvf archive.tar
 
 # Unbounded ellipsis span in pattern wraps to next command in some scenarios
+# ok: tar-insecure-flags
 wget https://git.kernel.org/torvalds/t/linux-6.8-rc1.tar.gz -O - | tar -xz -C / && mv linux-6.8-rc1 linux
 
 # This shouldn't match, but the ellipsis wrap picks up the p flag in this command and associates it with the previous command

--- a/generic/tar-insecure-flags.yaml
+++ b/generic/tar-insecure-flags.yaml
@@ -13,6 +13,8 @@ rules:
       impact: HIGH
       references:
         - https://man7.org/linux/man-pages/man1/tar.1.html
+    options:
+      generic_ellipsis_max_span: 0
     pattern-either:
       # A space character was left at the end of some patterns to help ensure
       # that the intended flag was used, and minimize the chance that another,


### PR DESCRIPTION
We have run across false positive matches on the tar-insecure-flags rule in some edge cases. Semgrep Support recommended this as a fix. 