### PR TITLE
use language-specific parsing for bash/dockerfile

### DIFF
--- a/generic/tar-insecure-flags.Dockerfile
+++ b/generic/tar-insecure-flags.Dockerfile
@@ -1,0 +1,18 @@
+# ruleid: tar-insecure-flags
+RUN tar -xvf --absolute-paths archive.tar
+
+# ruleid: tar-insecure-flags
+RUN tar -xvf -P archive.tar
+
+# ok: tar-insecure-flags
+RUN tar -xvf --Psomeotherflag archive.tar
+
+# ok: tar-insecure-flags
+RUN tar -xvf archive.tar
+
+# ok: tar-insecure-flags
+RUN tar -xvf some_archive.tar
+RUN wget "https://www.example.com/some/path" -P /tmp/some/local/path
+
+# ok: tar-insecure-flags
+RUN tar -xvf some_archive.tar && wget "https://www.example.com/some/path" -P /tmp/some/local/path

--- a/generic/tar-insecure-flags.yaml
+++ b/generic/tar-insecure-flags.yaml
@@ -1,24 +1,27 @@
 rules:
   - id: tar-insecure-flags
-    message: Found `tar` command using insecure flags
-    languages: [generic]
+    message: Found `tar` command using insecure flags for $PATH
+    languages:
+      - dockerfile
+      - bash
     severity: WARNING
     metadata:
       category: security
-      subcategory: [audit]
-      technology: [shell]
+      subcategory:
+        - audit
+      technology:
+        - shell
       cwe: "CWE-73: External Control of File Name or Path"
       confidence: MEDIUM
       likelihood: MEDIUM
       impact: HIGH
       references:
         - https://man7.org/linux/man-pages/man1/tar.1.html
+      license: AGPL-3.0 license
+      vulnerability_class:
+        - Path Traversal
     pattern-either:
-      # A space character was left at the end of some patterns to help ensure
-      # that the intended flag was used, and minimize the chance that another,
-      # longer flag that _starts with_ the intended flag results in a false
-      # positive
-      - pattern: "tar ... -P "
-      - pattern: "tar ... --absolute-paths"
-      - pattern: "tar ... --absolute-names"
-      - pattern: "tar ... --passphrase "
+      - pattern: tar $...OPTIONS -P $PATH
+      - pattern: tar $...OPTIONS --absolute-paths $PATH
+      - pattern: tar $...OPTIONS --absolute-names $PATH
+      - pattern: tar $...OPTIONS --passphrase $PHRASE


### PR DESCRIPTION
Avoids false positives introduced by ellipsis line wrapping to bad flags on other CLI invokes.

Alternative fix to #49 