### PR TITLE
Fix broken validation CI step

### DIFF
--- a/.github/workflows/semgrep-rules-test.yml
+++ b/.github/workflows/semgrep-rules-test.yml
@@ -20,7 +20,17 @@ jobs:
           python3 -m pip install semgrep
           python3 -m pip install jsonschema pyyaml
       - name: validations
-        run: semgrep --validate --config .
+        run: |
+          config_args=$(
+            for dir in $(
+              find . -type directory -maxdepth 1 -mindepth 1 -not -path '*/.*'
+            );
+            do
+              echo -n " --config $dir";
+            done
+          )
+          echo "Semgrep config arguments: $config_args"
+          semgrep scan --validate $config_args
       - name: tests
         run: semgrep --test --test-ignore-todo
       - name: metadata-tests
@@ -29,4 +39,4 @@ jobs:
           wget https://raw.githubusercontent.com/returntocorp/semgrep-rules/develop/metadata-schema.yaml.schm
           python ./validate-metadata.py -s ./metadata-schema.yaml.schm -f .
       - name: rules-tests
-        run: semgrep --config="r/yaml.semgrep" --severity ERROR .
+        run: semgrep scan --config="r/yaml.semgrep" --severity ERROR .

--- a/.github/workflows/semgrep-rules-test.yml
+++ b/.github/workflows/semgrep-rules-test.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           config_args=$(
             for dir in $(
-              find . -type directory -maxdepth 1 -mindepth 1 -not -path '*/.*'
+              find . -type d -maxdepth 1 -mindepth 1 -not -path '*/.*'
             );
             do
               echo -n " --config $dir";


### PR DESCRIPTION
The `validate` CI step is broken because it thinks our GHA YAML files are Semgrep rules: https://github.com/trailofbits/semgrep-rules/actions/runs/7656054543/job/21278776025?pr=49. This PR changes validation to only validate top-level, non-hidden directories.