### PR TITLE
Fix curl-unencrypted

### DIFF
--- a/generic/curl-unencrypted-url.sh
+++ b/generic/curl-unencrypted-url.sh
@@ -8,3 +8,9 @@ curl ftp://google.com > /dev/null
 
 # ok: curl-unencrypted-url
 curl https://google.com > /dev/null
+
+# ok: curl-unencrypted-url
+curl http://localhost > /dev/null
+
+# ok: curl-unencrypted-url
+curl http://127.0.0.1 > /dev/null

--- a/generic/curl-unencrypted-url.yaml
+++ b/generic/curl-unencrypted-url.yaml
@@ -13,6 +13,9 @@ rules:
       impact: HIGH
       references:
         - https://curl.se/docs/manpage.html
-    pattern-either:
-      - pattern: curl ... http://
-      - pattern: curl ... ftp://
+    patterns:
+      - pattern-either:
+        - pattern: curl ... http://
+        - pattern: curl ... ftp://
+      - pattern-not-inside: curl ... http://127.0.0.1
+      - pattern-not-inside: curl ... http://localhost

--- a/generic/curl-unencrypted-url.yaml
+++ b/generic/curl-unencrypted-url.yaml
@@ -15,7 +15,7 @@ rules:
         - https://curl.se/docs/manpage.html
     patterns:
       - pattern-either:
-        - pattern: curl ... http://
-        - pattern: curl ... ftp://
+          - pattern: curl ... http://
+          - pattern: curl ... ftp://
       - pattern-not-inside: curl ... http://127.0.0.1
       - pattern-not-inside: curl ... http://localhost


### PR DESCRIPTION
We had reports of false positives for this rule, this PR addresses it.

We shouldn't flag findings for localhost or 127.0.0.1