### PR TITLE
Added Swift rule for nil assignment to implicilty unwrapped optional

### DIFF
--- a/rules_table_generator.py
+++ b/rules_table_generator.py
@@ -5,7 +5,7 @@ from urllib.parse import quote
 import yaml
 import sys
 
-LANGUAGES = ['go', 'python', 'rs', 'javascript']
+LANGUAGES = ['go', 'python', 'rs', 'javascript', 'swift']
 IMPACT_MAP = {
     'LOW': "🟩",
     'MEDIUM': "🟧",

--- a/swift/AssignNilToImplicitlyUnwrappedOptional.swift
+++ b/swift/AssignNilToImplicitlyUnwrappedOptional.swift
@@ -1,0 +1,41 @@
+
+func LuhnCheck(_ pan: Int, check: Int?=nil) -> (Bool, Int?) {
+    var num: Int!
+    num = pan
+    var cd: Int! = nil
+    var sum = 0, digit = 0
+    var shouldDouble: Bool? = false
+    if let ch = check {
+        cd = ch
+    } else {
+        cd = num % 10
+        num /= 10
+    }
+    while num > 0 {
+        digit = num % 10
+        num /= 10
+        if let d = shouldDouble {
+            if d {
+                digit *= 2
+            }
+            shouldDouble!.toggle()
+        }
+        sum += digit
+    }
+    let correct_check = 10 - (sum % 10)
+    // ok: assign-nil-to-implicitly-unwrapped-optional
+    shouldDouble = nil
+    if cd == correct_check {
+        // ruleid: assign-nil-to-implicitly-unwrapped-optional
+        num = nil
+        return (true, cd)
+    } else {
+        // ruleid: assign-nil-to-implicitly-unwrapped-optional
+        cd = nil
+        return (false, nil)
+    }
+}
+
+print("Hello, world!")
+print(LuhnCheck(4429000011112224))
+print(LuhnCheck(4429000011112223))

--- a/swift/AssignNilToImplicitlyUnwrappedOptional.yaml
+++ b/swift/AssignNilToImplicitlyUnwrappedOptional.yaml
@@ -1,0 +1,33 @@
+rules:
+  - id: assign-nil-to-implicitly-unwrapped-optional
+    message: >
+      An implicitly unwrapped optional was assigned the value nil. If the
+      variable is dereferenced before it is assigned a non-nil value, a fatal
+      error will occur.
+    languages: [swift]
+    severity: WARNING
+    metadata:
+      category: security
+      subcategory:
+        - audit
+      technology:
+        - shell
+      cwe: "CWE-250: Execution with Unnecessary Privileges"
+      confidence: HIGH
+      likelihood: HIGH
+      impact: HIGH
+      references:
+        - https://docs.swift.org/swift-book/documentation/the-swift-programming-language/thebasics/#Implicitly-Unwrapped-Optionals
+      description: Implicitly unwrapped optionals are always unwrapped whenever they are dereferenced. Such a variable should never be assigned the value nil after initialization.
+    patterns:
+      - pattern-inside:
+          pattern-either:
+            - pattern: |
+                var $VAR: Int! = nil
+                (...)
+            - pattern: |
+                var $VAR: Int!
+                (...)
+      - pattern: $VAR = nil
+      - pattern-not: "var $VAR: Int! = nil"
+      - pattern-not-inside: "var $VAR: Int! = nil"


### PR DESCRIPTION
Added a Swift rule for assigning nil to an implicitly unwrapped optional (e.g., `var num: Int! = 5; num = nil;`). Updated the rule table generator to include Swift as another language. If we wanted, we could put Swift in a subdirectory called iOS with Objective-C rules in there as well (when we write some).