### PR TITLE
Remove unnecessary string escaping

### DIFF
--- a/yaml/ansible/apt-key-unencrypted-url.yaml
+++ b/yaml/ansible/apt-key-unencrypted-url.yaml
@@ -29,4 +29,4 @@ rules:
             - pattern: url
       - metavariable-regex:
           metavariable: $VALUE
-          regex: '(?i)^(http|ftp)://.*'
+          regex: "(?i)^(http|ftp)://.*"

--- a/yaml/ansible/apt-key-unencrypted-url.yaml
+++ b/yaml/ansible/apt-key-unencrypted-url.yaml
@@ -29,4 +29,4 @@ rules:
             - pattern: url
       - metavariable-regex:
           metavariable: $VALUE
-          regex: "(?i)^(http|ftp):\/\/.*"
+          regex: '(?i)^(http|ftp)://.*'

--- a/yaml/ansible/apt-unencrypted-url.yaml
+++ b/yaml/ansible/apt-unencrypted-url.yaml
@@ -29,4 +29,4 @@ rules:
             - pattern: deb
       - metavariable-regex:
           metavariable: $VALUE
-          regex: '(?i)^(http|ftp)://.*'
+          regex: "(?i)^(http|ftp)://.*"

--- a/yaml/ansible/apt-unencrypted-url.yaml
+++ b/yaml/ansible/apt-unencrypted-url.yaml
@@ -29,4 +29,4 @@ rules:
             - pattern: deb
       - metavariable-regex:
           metavariable: $VALUE
-          regex: "(?i)^(http|ftp):\/\/.*"
+          regex: '(?i)^(http|ftp)://.*'

--- a/yaml/ansible/dnf-unencrypted-url.yaml
+++ b/yaml/ansible/dnf-unencrypted-url.yaml
@@ -33,4 +33,4 @@ rules:
             - pattern: pkg
       - metavariable-regex:
           metavariable: $VALUE
-          regex: "(?i)^(http|ftp):\/\/.*"
+          regex: '(?i)^(http|ftp)://.*'

--- a/yaml/ansible/dnf-unencrypted-url.yaml
+++ b/yaml/ansible/dnf-unencrypted-url.yaml
@@ -33,4 +33,4 @@ rules:
             - pattern: pkg
       - metavariable-regex:
           metavariable: $VALUE
-          regex: '(?i)^(http|ftp)://.*'
+          regex: "(?i)^(http|ftp)://.*"

--- a/yaml/ansible/get-url-unencrypted-url.yaml
+++ b/yaml/ansible/get-url-unencrypted-url.yaml
@@ -39,4 +39,4 @@ rules:
             - pattern: url
       - metavariable-regex:
           metavariable: $VALUE
-          regex: '(?i)^(http|ftp)://.*'
+          regex: "(?i)^(http|ftp)://.*"

--- a/yaml/ansible/get-url-unencrypted-url.yaml
+++ b/yaml/ansible/get-url-unencrypted-url.yaml
@@ -39,4 +39,4 @@ rules:
             - pattern: url
       - metavariable-regex:
           metavariable: $VALUE
-          regex: "(?i)^(http|ftp):\/\/.*"
+          regex: '(?i)^(http|ftp)://.*'

--- a/yaml/ansible/rpm-key-unencrypted-url.yaml
+++ b/yaml/ansible/rpm-key-unencrypted-url.yaml
@@ -29,4 +29,4 @@ rules:
             - pattern: key
       - metavariable-regex:
           metavariable: $VALUE
-          regex: '(?i)^(http|ftp)://.*'
+          regex: "(?i)^(http|ftp)://.*"

--- a/yaml/ansible/rpm-key-unencrypted-url.yaml
+++ b/yaml/ansible/rpm-key-unencrypted-url.yaml
@@ -29,4 +29,4 @@ rules:
             - pattern: key
       - metavariable-regex:
           metavariable: $VALUE
-          regex: "(?i)^(http|ftp):\/\/.*"
+          regex: '(?i)^(http|ftp)://.*'

--- a/yaml/ansible/unarchive-unencrypted-url.yaml
+++ b/yaml/ansible/unarchive-unencrypted-url.yaml
@@ -29,4 +29,4 @@ rules:
             - pattern: src
       - metavariable-regex:
           metavariable: $VALUE
-          regex: '(?i)^(http|ftp)://.*'
+          regex: "(?i)^(http|ftp)://.*"

--- a/yaml/ansible/unarchive-unencrypted-url.yaml
+++ b/yaml/ansible/unarchive-unencrypted-url.yaml
@@ -29,4 +29,4 @@ rules:
             - pattern: src
       - metavariable-regex:
           metavariable: $VALUE
-          regex: "(?i)^(http|ftp):\/\/.*"
+          regex: '(?i)^(http|ftp)://.*'

--- a/yaml/ansible/yum-unencrypted-url.yaml
+++ b/yaml/ansible/yum-unencrypted-url.yaml
@@ -30,4 +30,4 @@ rules:
             - pattern: pkg
       - metavariable-regex:
           metavariable: $VALUE
-          regex: '(?i)^(http|ftp)://.*'
+          regex: "(?i)^(http|ftp)://.*"

--- a/yaml/ansible/yum-unencrypted-url.yaml
+++ b/yaml/ansible/yum-unencrypted-url.yaml
@@ -30,4 +30,4 @@ rules:
             - pattern: pkg
       - metavariable-regex:
           metavariable: $VALUE
-          regex: "(?i)^(http|ftp):\/\/.*"
+          regex: '(?i)^(http|ftp)://.*'

--- a/yaml/ansible/zypper-repository-unencrypted-url.yaml
+++ b/yaml/ansible/zypper-repository-unencrypted-url.yaml
@@ -29,4 +29,4 @@ rules:
             - pattern: community.general.zypper_repository
       - metavariable-regex:
           metavariable: $VALUE
-          regex: '(?i)^(http|ftp)://.*'
+          regex: "(?i)^(http|ftp)://.*"

--- a/yaml/ansible/zypper-repository-unencrypted-url.yaml
+++ b/yaml/ansible/zypper-repository-unencrypted-url.yaml
@@ -29,4 +29,4 @@ rules:
             - pattern: community.general.zypper_repository
       - metavariable-regex:
           metavariable: $VALUE
-          regex: "(?i)^(http|ftp):\/\/.*"
+          regex: '(?i)^(http|ftp)://.*'

--- a/yaml/ansible/zypper-unencrypted-url.yaml
+++ b/yaml/ansible/zypper-unencrypted-url.yaml
@@ -30,4 +30,4 @@ rules:
             - pattern: community.general.zypper
       - metavariable-regex:
           metavariable: $VALUE
-          regex: "(?i)^(http|ftp):\/\/.*"
+          regex: '(?i)^(http|ftp)://.*'

--- a/yaml/ansible/zypper-unencrypted-url.yaml
+++ b/yaml/ansible/zypper-unencrypted-url.yaml
@@ -30,4 +30,4 @@ rules:
             - pattern: community.general.zypper
       - metavariable-regex:
           metavariable: $VALUE
-          regex: '(?i)^(http|ftp)://.*'
+          regex: "(?i)^(http|ftp)://.*"


### PR DESCRIPTION
There are two benefits here:

1. Avoiding the need for escaping makes things more clear.
2. This form of backslash escaping was actually only [added in YAML 1.2.0](https://yaml.org/spec/1.2.2/ext/changes/). [Some YAML parsers](https://github.com/go-yaml/yaml/issues/797) are not fully compliant with YAML 1.2.0, so they fail to parse these rules. This isn't a problem for Semgrep, but can be an issue for other tools or libraries analyzing these rules.