### PR TITLE
Missing (r)unlock broken after semgrep update

### DIFF
--- a/go/missing-runlock-on-rwmutex.go
+++ b/go/missing-runlock-on-rwmutex.go
@@ -124,6 +124,7 @@ func (c *RWContainer) inc6b(name string) error {
 	defer func() {
 		fmt.Println("before runlock")
 		unlocker()
+		// todook: missing-runlock-on-rwmutex
 		fmt.Println("after runlock")
 	}()
 	// todook: missing-runlock-on-rwmutex

--- a/go/missing-unlock-before-return.go
+++ b/go/missing-unlock-before-return.go
@@ -152,6 +152,7 @@ func (c *Container) inc6b(name string) error {
 	defer func() {
 		fmt.Println("before unlock")
 		unlocker()
+		// todook: missing-unlock-before-return
 		fmt.Println("after unlock")
 	}()
 	// todook: missing-unlock-before-return


### PR DESCRIPTION
Seems like Semgrep two things in new version that break our rules:
* const propagation works in different way: the `unlocker := c.mu.RUnlock` is not propagated to `unlocker()`
* implicit `return` is added at the end of `defer func() {` block

Something to investigate and fix in our rules.