### PR TITLE
Add exclusion patterns for curl-unecrypted-url

### DIFF
--- a/generic/curl-unencrypted-url.sh
+++ b/generic/curl-unencrypted-url.sh
@@ -14,3 +14,9 @@ curl http://localhost > /dev/null
 
 # ok: curl-unencrypted-url
 curl http://127.0.0.1 > /dev/null
+
+# ok: curl-unencrypted-url
+curl http://169.254.169.254 > /dev/null
+
+# ok: curl-unencrypted-url
+curl http://metadata.google.internal > /dev/null

--- a/generic/curl-unencrypted-url.sh
+++ b/generic/curl-unencrypted-url.sh
@@ -17,6 +17,9 @@ curl http://127.0.0.1 > /dev/null
 
 # ok: curl-unencrypted-url
 curl http://169.254.169.254 > /dev/null
+#
+# ok: curl-unencrypted-url
+curl http://[fd00:ec2::254] > /dev/null
 
 # ok: curl-unencrypted-url
 curl http://metadata.google.internal > /dev/null

--- a/generic/curl-unencrypted-url.yaml
+++ b/generic/curl-unencrypted-url.yaml
@@ -20,4 +20,5 @@ rules:
       - pattern-not-inside: curl ... http://127.0.0.1
       - pattern-not-inside: curl ... http://localhost
       - pattern-not-inside: curl ... http://169.254.169.254
+      - pattern-not-inside: curl ... http://[fd00:ec2::254]
       - pattern-not-inside: curl ... http://metadata.google.internal

--- a/generic/curl-unencrypted-url.yaml
+++ b/generic/curl-unencrypted-url.yaml
@@ -19,3 +19,5 @@ rules:
           - pattern: curl ... ftp://
       - pattern-not-inside: curl ... http://127.0.0.1
       - pattern-not-inside: curl ... http://localhost
+      - pattern-not-inside: curl ... http://169.254.169.254
+      - pattern-not-inside: curl ... http://metadata.google.internal


### PR DESCRIPTION
`curl-unecrypted-url` produces a lot of false positives on repositories with lots of cloud infrastructure code for AWS or GCP. These providers use link local URLs via HTTP without TLS. This is equivalent to localhost patterns.