### PR TITLE
add exclusion patterns for tarfile-extractall-traversal

### DIFF
--- a/python/tarfile-extractall-traversal.py
+++ b/python/tarfile-extractall-traversal.py
@@ -2,11 +2,9 @@ import argparse
 import tarfile
 
 def get_parser():
-    parser = argparse.ArgumentParser(description='Process zip files.')
-    parser.add_argument('--path', type=str, required=True,
-                        help='Path to zip file')
-    parser.add_argument('--save-path', type=str, required=True,
-                            help='Output path')
+    parser = argparse.ArgumentParser(description="Process tar files.")
+    parser.add_argument("--path", type=str, required=True, help="Path to tar file")
+    parser.add_argument("--save-path", type=str, required=True, help="Output path")
     return parser
 
 
@@ -17,13 +15,11 @@ def extract_1(args):
     with tarfile.open(path) as f:
         f.extractall(save_path)
 
-
 def extract_2(args):
     path = args.path
     save_path = args.save_path
     # ruleid: tarfile-extractall-traversal
     tarfile.open(path).extractall(save_path)
-
 
 def extract_3(args):
     path = args.path
@@ -33,24 +29,48 @@ def extract_3(args):
     tf.extractall(save_path)
 
 def extract_4(args, tarobj):
+    save_path = args.save_path
     # ruleid: tarfile-extractall-traversal
     tf = tarfile.open(mode='r', fileobj=None)
     tf.extractall(save_path)
 
 def extract_5(args, tarobj):
+    save_path = args.save_path
     # ok: tarfile-extractall-traversal
     tf = tarfile.open(mode='r', fileobj=None)
     tf.extractall(save_path, members=safu_members())
 
 def extract_6(args, tarobj):
+    save_path = args.save_path
     # ok: tarfile-extractall-traversal
     tf = tarfile.open(mode='r', fileobj=None)
     tf.extractall(members=safu_members(), numeric_owner=True, path=save_path)
 
 def extract_7(args, tarobj):
+    save_path = args.save_path
     # todoruleid: tarfile-extractall-traversal
     tf = tarfile.open(mode='r', fileobj=None)
     tf.extractall(members=None, numeric_owner=True, path=save_path)
+
+def extract_8(args):
+    path = args.path
+    save_path = args.save_path
+    # ok: tarfile-extractall-traversal
+    with tarfile.open(path) as f:
+        f.extractall(save_path, filter='data')
+
+def extract_9(args):
+    path = args.path
+    save_path = args.save_path
+    # ok: tarfile-extractall-traversal
+    tarfile.open(path).extractall(save_path, filter='data')
+
+def extract_10(args):
+    path = args.path
+    save_path = args.save_path
+    # ok: tarfile-extractall-traversal
+    tf = tarfile.open(path)
+    tf.extractall(save_path, filter='data')
 
 def run():
     parser = get_parser()
@@ -62,6 +82,9 @@ def run():
     extract_5(args)
     extract_6(args)
     extract_7(args)
+    extract_8(args)
+    extract_9(args)
+    extract_10(args)
 
 
 if __name__ == '__main__':

--- a/python/tarfile-extractall-traversal.yaml
+++ b/python/tarfile-extractall-traversal.yaml
@@ -39,3 +39,13 @@ rules:
           $TAR = tarfile.open(...)
           ...
           $TAR.extractall(..., members=$MEMBERS, ...)
+      - pattern-not: |
+          with tarfile.open(...) as $TAR:
+              ...
+              $TAR.extractall(..., filter=$FILTER, ...)
+      - pattern-not: |
+          tarfile.open(...).extractall(..., filter=$FILTER, ...)
+      - pattern-not: |
+          $TAR = tarfile.open(...)
+          ...
+          $TAR.extractall(..., filter=$FILTER, ...)


### PR DESCRIPTION
As per [PEP706](https://peps.python.org/pep-0706/) the filter arg is used to prevent directory traversal