### PR TITLE
Use string metavariable for GHA 'uses' field

### DIFF
--- a/yaml/github-actions/aws-secret-key.test.yaml
+++ b/yaml/github-actions/aws-secret-key.test.yaml
@@ -19,6 +19,13 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
       - name: Set up AWS credentials
+        uses: "aws-actions/configure-aws-credentials@v4"
+        # ruleid: aws-secret-key
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+      - name: Set up AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         # ruleid: aws-secret-key
         env:

--- a/yaml/github-actions/aws-secret-key.yaml
+++ b/yaml/github-actions/aws-secret-key.yaml
@@ -19,7 +19,7 @@ rules:
         - https://github.com/aws-actions/configure-aws-credentials
     patterns:
       - pattern-inside: |
-          uses: $ACTION
+          uses: "$ACTION"
           ...
       - metavariable-regex:
           metavariable: $ACTION

--- a/yaml/github-actions/azure-principal-secret.test.yaml
+++ b/yaml/github-actions/azure-principal-secret.test.yaml
@@ -15,6 +15,11 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
       - name: Azure login
+        uses: "azure/login@v2"
+        # ruleid: azure-principal-secret
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - name: Azure login
         uses: azure/login@v2
         # ok: azure-principal-secret
         with:

--- a/yaml/github-actions/azure-principal-secret.yaml
+++ b/yaml/github-actions/azure-principal-secret.yaml
@@ -19,7 +19,7 @@ rules:
         - https://github.com/Azure/login
     patterns:
       - pattern-inside: |
-          uses: $ACTION
+          uses: "$ACTION"
           ...
       - metavariable-regex:
           metavariable: $ACTION

--- a/yaml/github-actions/gcp-credentials-json.test.yaml
+++ b/yaml/github-actions/gcp-credentials-json.test.yaml
@@ -19,7 +19,7 @@ jobs:
           credentials_json: "${{ secrets.GOOGLE_CREDENTIALS }}"
       - id: auth
         name: Authenticate to GCP
-        uses: 'google-github-actions/auth@v0.3.1'
+        uses: "google-github-actions/auth@v0.3.1"
         # ruleid: gcp-credentials-json
         with:
           credentials_json: "${{ secrets.GOOGLE_CREDENTIALS }}"

--- a/yaml/github-actions/gcp-credentials-json.test.yaml
+++ b/yaml/github-actions/gcp-credentials-json.test.yaml
@@ -19,6 +19,12 @@ jobs:
           credentials_json: "${{ secrets.GOOGLE_CREDENTIALS }}"
       - id: auth
         name: Authenticate to GCP
+        uses: 'google-github-actions/auth@v0.3.1'
+        # ruleid: gcp-credentials-json
+        with:
+          credentials_json: "${{ secrets.GOOGLE_CREDENTIALS }}"
+      - id: auth
+        name: Authenticate to GCP
         uses: google-github-actions/auth@v0.3.1
         # ok: gcp-credentials-json
         with:

--- a/yaml/github-actions/gcp-credentials-json.yaml
+++ b/yaml/github-actions/gcp-credentials-json.yaml
@@ -19,7 +19,7 @@ rules:
         - https://github.com/google-github-actions/auth
     patterns:
       - pattern-inside: |
-          uses: $ACTION
+          uses: "$ACTION"
           ...
       - metavariable-regex:
           metavariable: $ACTION

--- a/yaml/github-actions/jfrog-hardcoded-credential.test.yaml
+++ b/yaml/github-actions/jfrog-hardcoded-credential.test.yaml
@@ -21,6 +21,12 @@ jobs:
           JF_ACCESS_TOKEN: ${{ secrets.JF_ACCESS_TOKEN }}
           # ruleid: jfrog-hardcoded-credential
           JF_ENV_1: ${{ secrets.JF_SECRET_ENV_1 }}
+      - uses: "jfrog/setup-jfrog-cli@v4"
+        env:
+          JF_URL: ${{ secrets.JF_URL }}
+          JF_USER: ${{ secrets.JF_USER }}
+          # ruleid: jfrog-hardcoded-credential
+          JF_PASSWORD: ${{ secrets.JF_PASSWORD }}
       - run: |
           jf rt ping
       - uses: jfrog/setup-jfrog-cli@v4

--- a/yaml/github-actions/jfrog-hardcoded-credential.yaml
+++ b/yaml/github-actions/jfrog-hardcoded-credential.yaml
@@ -18,7 +18,7 @@ rules:
         - https://github.com/jfrog/setup-jfrog-cli#authorization
     patterns:
       - pattern-inside: |
-          uses: $ACTION
+          uses: "$ACTION"
           ...
       - metavariable-regex:
           metavariable: $ACTION

--- a/yaml/github-actions/pypi-publish-password.test.yaml
+++ b/yaml/github-actions/pypi-publish-password.test.yaml
@@ -21,5 +21,10 @@ jobs:
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
       - name: Publish package distributions to PyPI
+        uses: 'pypa/gh-action-pypi-publish@release/v1'
+        # ruleid: pypi-publish-password
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+      - name: Publish package distributions to PyPI
         # ok: pypi-publish-password
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/yaml/github-actions/pypi-publish-password.test.yaml
+++ b/yaml/github-actions/pypi-publish-password.test.yaml
@@ -21,7 +21,7 @@ jobs:
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
       - name: Publish package distributions to PyPI
-        uses: 'pypa/gh-action-pypi-publish@release/v1'
+        uses: "pypa/gh-action-pypi-publish@release/v1"
         # ruleid: pypi-publish-password
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/yaml/github-actions/pypi-publish-password.yaml
+++ b/yaml/github-actions/pypi-publish-password.yaml
@@ -19,7 +19,7 @@ rules:
         - https://github.com/pypa/gh-action-pypi-publish
     patterns:
       - pattern-inside: |
-          uses: $ACTION
+          uses: "$ACTION"
           ...
       - metavariable-regex:
           metavariable: $ACTION

--- a/yaml/github-actions/vault-token.test.yaml
+++ b/yaml/github-actions/vault-token.test.yaml
@@ -23,6 +23,17 @@ jobs:
             secret/data/ci/aws secretKey | AWS_SECRET_ACCESS_KEY ;
             secret/data/ci npm_token
       - name: Import Secrets
+        uses: "hashicorp/vault-action@v2.4.0"
+        # ruleid: vault-token
+        with:
+          url: https://vault.example.com:8200
+          token: ${{ secrets.VAULT_TOKEN }}
+          caCertificate: ${{ secrets.VAULT_CA_CERT }}
+          secrets: |
+            secret/data/ci/aws accessKey | AWS_ACCESS_KEY_ID ;
+            secret/data/ci/aws secretKey | AWS_SECRET_ACCESS_KEY ;
+            secret/data/ci npm_token
+      - name: Import Secrets
         uses: hashicorp/vault-action@v2.4.0
         with:
           url: https://vault.example.com:8200

--- a/yaml/github-actions/vault-token.yaml
+++ b/yaml/github-actions/vault-token.yaml
@@ -19,7 +19,7 @@ rules:
         - https://github.com/hashicorp/vault-action
     patterns:
       - pattern-inside: |
-          uses: $ACTION
+          uses: "$ACTION"
           ...
       - metavariable-regex:
           metavariable: $ACTION


### PR DESCRIPTION
Using string metavariable will automatically catch the following cases:

- `someorg/some-action`
- `"someorg/some-action"`
- `'someorg/some-action'`

Previously it would only catch the first case.