### PR TITLE
Fix iterate-over-empty-map

### DIFF
--- a/go/iterate-over-empty-map.go
+++ b/go/iterate-over-empty-map.go
@@ -88,3 +88,22 @@ func iter1_FP_5() {
 		keys = append(keys, k)
 	}
 }
+
+
+func emptyMapIter() {
+  // ruleid: iterate-over-empty-map
+  c := make(map[string]string)
+  for k := range c {
+    // do stuff
+  }
+}
+
+func notEmptyMapIter() {
+   // ok: iterate-over-empty-map
+  c := map[string]string {
+    "foo": "bar"
+  }
+  for k := range c {
+    // do stuff
+  }
+}

--- a/go/iterate-over-empty-map.yaml
+++ b/go/iterate-over-empty-map.yaml
@@ -18,7 +18,7 @@ rules:
 
     patterns:
       - pattern: |
-          $C = make(map[$T1] $T2, ...)
+          $C = make(map[$T1] $T2)
           ...
           for $K := range $C { ... }
       - pattern-not: |


### PR DESCRIPTION
We got reports of false positives for this rule.

Turns out the existing pattern was matching things like:

```
func notEmptyMapIter() {
   // ok: iterate-over-empty-map
  c := map[string]string {
    "foo": "bar"
  }
  for k := range c {
    // do stuff
  }
}
```

This is due to the current pattern matching all things with the `,...` so just removed that in the positive pattern.