### PR TITLE
Remove redundant fstring patterns

### DIFF
--- a/python/pandas-eval.yaml
+++ b/python/pandas-eval.yaml
@@ -28,12 +28,10 @@ rules:
           - patterns:
               - pattern: pandas.DataFrame.$FN(...)
               - pattern-not: pandas.DataFrame.$FN("...", ...)
-              - pattern-not: pandas.DataFrame.$FN(f"", ...)
 
           - patterns:
               - pattern: pandas.$FN(...)
               - pattern-not: pandas.$FN("...", ...)
-              - pattern-not: pandas.$FN(f"", ...)
 
           - patterns:
               - pattern-inside: |
@@ -41,7 +39,6 @@ rules:
                   ...
               - pattern: $DF.$FN(...)
               - pattern-not: $DF.$FN("...", ...)
-              - pattern-not: $DF.$FN(f"", ...)
 
       - metavariable-regex:
           metavariable: $FN


### PR DESCRIPTION
No more needed after https://github.com/semgrep/semgrep/commit/57ee2be59694ce9eaaf70cd3077732669df1c7c8

Wait with merge for the commit above to be released.